### PR TITLE
検索フォームのカテゴリープルダウンに商品数表示機能の改修のため（パフォーマンス向上）

### DIFF
--- a/src/main/java/com/example/repository/CategoryRepository.java
+++ b/src/main/java/com/example/repository/CategoryRepository.java
@@ -1,9 +1,10 @@
 package com.example.repository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -12,16 +13,19 @@ import org.springframework.stereotype.Repository;
 
 import com.example.domain.Category;
 
+/**
+ * @author seiji_kitahara
+ *
+ */
 @Repository
 public class CategoryRepository {
 
 	@Autowired
 	private NamedParameterJdbcTemplate template;
-	@Autowired
-	private JdbcTemplate jdbcTemplate;
 	
 	private final static String TABLE_NAME_CATEGORY = "categories";
 	private final static String TABLE_NAME_TREEPATH = "treepaths";
+	private final static String TABLE_NAME_ITEM = "items";
 	
 	private final static RowMapper<Category> CATEGORY_ROW_MAPPER = (rs, i) -> {
 	
@@ -43,6 +47,36 @@ public class CategoryRepository {
 		category.setNameAll(rs.getString("c_name_all"));
 		category.setHierarchy(rs.getInt("c_hierarchy"));
 		return category;
+	};
+	
+	private final static ResultSetExtractor<List<List<Category>>> RESULT_SET_EXTRACTOR_FOR_COUNTITEM = (rs) -> {
+
+		List<List<Category>> categoryListByHierarchy = new ArrayList<>();
+		List<Category> categoryList = null;
+		int previousHierarchy = -1;
+		int nowHierarchy = 0;
+
+		while (rs.next()) {
+			nowHierarchy = rs.getInt("c_hierarchy");
+			if(nowHierarchy != previousHierarchy) {
+				categoryList = new ArrayList<>();
+				categoryListByHierarchy.add(categoryList);
+			}
+			// Categoryの空リストを作成
+			Category category = new Category();
+			category.setCategoryId(rs.getInt("c_category_id"));
+			category.setParentId(rs.getInt("c_parent_id"));
+			category.setCategoryName(rs.getString("c_categoy_name"));
+			category.setNameAll(rs.getString("c_name_all"));
+			category.setHierarchy(rs.getInt("c_hierarchy"));
+//			int itemNum = rs.getInt("count(i.item_id)");
+			category.setItemNum(rs.getInt("item_count"));
+			categoryList.add(category);
+			
+			previousHierarchy = nowHierarchy;
+		}
+
+		return categoryListByHierarchy;
 	};
 	
 	/**
@@ -69,25 +103,27 @@ public class CategoryRepository {
 	 * @param 階層数
 	 * @return 対象階層に該当するカテゴリー情報が詰まったリスト
 	 */
-	public List<Category> findByHierarchy(Integer hierarchy){
+	public List<List<Category>> findByHierarchy(){
 		StringBuilder sql = new StringBuilder();
-		sql.append("SELECT category_id, parent_id, category_name, name_all, hierarchy ");
-		sql.append("FROM " + TABLE_NAME_CATEGORY + " WHERE hierarchy = :hierarchy ORDER BY category_id;");
-		SqlParameterSource param = new MapSqlParameterSource().addValue("hierarchy", hierarchy);
-		List<Category> categoryList = template.query(sql.toString(), param, CATEGORY_ROW_MAPPER);
-		if(categoryList.size() == 0) {
+		sql.append("SELECT c.category_id AS c_category_id, c.parent_id AS c_parent_id, c.category_name AS c_categoy_name, ");
+		sql.append("c.name_all AS c_name_all, c.hierarchy AS c_hierarchy, count(i.item_id) AS item_count ");
+		sql.append("FROM " + TABLE_NAME_CATEGORY + " AS c ");
+		sql.append("JOIN " + TABLE_NAME_TREEPATH + " AS t ON c.category_id = t.ancestor_id ");
+		sql.append("JOIN " + TABLE_NAME_ITEM + " AS i ON t.descendant_id = i.category_id ");
+		sql.append("GROUP BY c.category_id ORDER BY c.hierarchy, c.category_id;");
+		List<List<Category>> categoryListByHierarchy = template.query(sql.toString(), RESULT_SET_EXTRACTOR_FOR_COUNTITEM);
+		if(categoryListByHierarchy.size() == 0) {
 			return null;
 		}
-		return categoryList;
+		return categoryListByHierarchy;
 	}
 	
-	public Integer checkMaxHierarchy() {
-		String sql = "SELECT MAX(hierarchy) FROM " + TABLE_NAME_CATEGORY + ";";
-//		JdbcTemplate jdbcTemplate = new JdbcTemplate();
-		Integer maxHierarchy = jdbcTemplate.queryForObject(sql, Integer.class);
-		return maxHierarchy;
-	}
-	
+	/**
+	 * 指定カテゴリーIDを元に上位層（親）カテゴリーを取得する.
+	 * 
+	 * @param categoryId
+	 * @return
+	 */
 	public List<Category> findCategoryAllByCategoryId(Integer categoryId){
 		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT c.category_id AS c_category_id, c.parent_id AS c_parent_id,");

--- a/src/main/java/com/example/service/CategoryService.java
+++ b/src/main/java/com/example/service/CategoryService.java
@@ -37,18 +37,19 @@ public class CategoryService {
 		// カテゴリー階層の最大値を確認
 //		Integer maxHierarchy = categoryRepository.checkMaxHierarchy();
 		
-		List<List<Category>> categoryList = new ArrayList<>();
+		List<List<Category>> categoryList = categoryRepository.findByHierarchy();
+		categoryList.get(0).get(0).setCategoryName("カテゴリー無し");
 		
 		// カテゴリー毎にリスト化し、リストに詰める
-		for(int i = 0 ; i <= 4 ; i ++) {
-			List<Category> categorySmallList = new ArrayList<>();
-			categorySmallList = categoryRepository.findByHierarchy(i);
-			if(i == 0) {
-				categorySmallList.get(i).setCategoryName("カテゴリー無し");
-			}
-			categorySmallList = getItemNumByCategory(categorySmallList);
-			categoryList.add(categorySmallList);
-		}
+//		for(int i = 0 ; i <= 4 ; i ++) {
+//			List<Category> categorySmallList = new ArrayList<>();
+//			categorySmallList = categoryRepository.findByHierarchy(i);
+//			if(i == 0) {
+//				categorySmallList.get(i).setCategoryName("カテゴリー無し");
+//			}
+//			categorySmallList = getItemNumByCategory(categorySmallList);
+//			categoryList.add(categorySmallList);
+//		}
 		return categoryList;
 	}
 	


### PR DESCRIPTION
カテゴリーごとの商品件数を取得するSQL発行回数を減らす形（複数回→１回）に変更。
また、不要なメソッドの削除、Javadocコメントの追加。